### PR TITLE
Migriere Python Skripte nach Python 3 (und Debian 10)

### DIFF
--- a/roles/gateway-server/tasks/openvpn.yml
+++ b/roles/gateway-server/tasks/openvpn.yml
@@ -1,6 +1,9 @@
 - name: openvpn installieren
   apt: pkg=openvpn state=present
 
+- name: Abhaengigkeiten fuer Python connect_script installieren
+  apt: pkg=python3-packaging state=present
+
 - name: VPN-Gruppe anlegen
   user: state=present
         name=openvpn

--- a/roles/python-module/files/opennet/addresses.py
+++ b/roles/python-module/files/opennet/addresses.py
@@ -4,7 +4,7 @@ Dieses Python-Modul stellt Funktionen zur IP-Ermittlung basierend auf Client-Zer
 """
 
 import re
-from ipaddr import IPv4Address, IPv6Address, IPv4Network, IPv6Network
+from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network, ip_address
 
 
 # Jedem Client werden zehn Ports zugeteilt.
@@ -48,7 +48,7 @@ class NodeInfo(object):
             raise ValueError('Invalid CN %r.' % client_cn)
         if ipv4_base:
             # wir beginnen mit der zweiten IP des Netzwerks (die erste verwendet der Server)
-            self.ipv4_address = ipv4_base + int(ipv4_offset) + IPV4_FACTOR * (cn_address - 1) + 2
+            self.ipv4_address = ip_address(int(ipv4_base) + int(ipv4_offset) + IPV4_FACTOR * (cn_address - 1) + 2)
         else:
             self.ipv4_address = None
         if ipv6_base:
@@ -64,8 +64,8 @@ class NodeInfo(object):
 
 
 def parse_ipv4_and_net(ip, netmask):
-    return IPv4Network("%s/%s" % (ip, netmask)).masked().ip
+    return IPv4Network("%s/%s" % (ip, netmask), strict=False).network_address
 
 
 def parse_ipv6_and_net(ip):
-    return IPv6Network(ip).masked().ip
+    return IPv6Network(ip, strict=False).network_address

--- a/roles/python-module/files/test_addresses.py
+++ b/roles/python-module/files/test_addresses.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+#
+# Unit tests
+#
+
+from ipaddress import IPv4Network, IPv4Address, IPv6Network, IPv6Address
+import unittest
+from opennet.addresses import NodeInfo, parse_ipv4_and_net, parse_ipv6_and_net
+
+class TestAddresses(unittest.TestCase):
+    def test_parse_ipv4_and_net(self):
+        self.assertEqual(parse_ipv4_and_net("10.1.0.0", "8"), IPv4Address("10.0.0.0"))
+        self.assertEqual(parse_ipv4_and_net("10.1.2.0", "16"), IPv4Address("10.1.0.0"))
+        self.assertEqual(parse_ipv4_and_net("10.1.2.3", "32"), IPv4Address("10.1.2.3"))
+        self.assertEqual(parse_ipv4_and_net("192.168.3.0", "24"), IPv4Address("192.168.3.0"))
+
+    def test_parse_ipv6_and_net(self):
+        self.assertEqual(parse_ipv6_and_net("1111:2222:3333:4444::/64"), IPv6Address("1111:2222:3333:4444::"))
+        self.assertEqual(parse_ipv6_and_net("1111:2222:3333:4444:5:6:7:8/64"), IPv6Address("1111:2222:3333:4444::"))
+        self.assertEqual(parse_ipv6_and_net("1111:2222:3333::/64"), IPv6Address("1111:2222:3333::"))
+        self.assertEqual(parse_ipv6_and_net("1111:2222:3333::999/64"), IPv6Address("1111:2222:3333::"))
+
+    def test_NodeInfo(self):
+        # live examples:
+        #  $ cat /var/log/openvpn/opennet_users.status.log
+        #     10.1.4.114,1.29.aps.on,139.30.241.206:45279,Mon Oct  3 22:10:42 2022
+        #  $ iptables -t nat -L | less
+        #     DNAT       tcp  --  anywhere             anywhere             tcp dpts:10280:10289 to:10.1.4.114
+        self.assertEqual(str(NodeInfo("1.29.aps.on", IPv4Address("10.1.0.0"), IPv6Address("2001:db8::"))),
+            "NodeInfo(ipv4_address='10.1.4.114', ipv6_address='2001:db8::1:1:1d:0', port_first=10280, port_last=10289)")
+        self.assertEqual(str(NodeInfo("1.29.aps.on", parse_ipv4_and_net("10.1.2.0", "16"),  parse_ipv6_and_net("2001:db8::/64"))),
+            "NodeInfo(ipv4_address='10.1.4.114', ipv6_address='2001:db8::1:1:1d:0', port_first=10280, port_last=10289)")
+        
+        # 10.1.19.170,2.235.aps.on,31.17.105.163:47823,Mon Oct  3 23:10:34 2022
+        # DNAT       tcp  --  anywhere             anywhere             tcp dpts:17440:17449 to:10.1.19.170
+        self.assertEqual(str(NodeInfo("2.235.aps.on", IPv4Address("10.1.0.0"), IPv6Address("2001:db8::"))),
+            "NodeInfo(ipv4_address='10.1.19.170', ipv6_address='2001:db8::1:2:eb:0', port_first=17440, port_last=17449)")
+        
+        # 10.1.19.70,2.210.aps.on,62.214.244.79:43629,Mon Oct  3 23:10:31 2022
+        # DNAT       tcp  --  anywhere             anywhere             tcp dpts:17190:17199 to:10.1.19.70
+        self.assertEqual(str(NodeInfo("2.210.aps.on", IPv4Address("10.1.0.0"), IPv6Address("2001:db8::"))),
+            "NodeInfo(ipv4_address='10.1.19.70', ipv6_address='2001:db8::1:2:d2:0', port_first=17190, port_last=17199)")
+        
+        # 10.1.18.62,2.144.aps.on,213.254.32.26:36666,Mon Oct  3 23:10:34 2022
+        # DNAT       tcp  --  anywhere             anywhere             tcp dpts:16530:16539 to:10.1.18.62
+        self.assertEqual(str(NodeInfo("2.144.aps.on", IPv4Address("10.1.0.0"), IPv6Address("2001:db8::"))),
+            "NodeInfo(ipv4_address='10.1.18.62', ipv6_address='2001:db8::1:2:90:0', port_first=16530, port_last=16539)")
+        
+        # 10.1.6.190,1.176.aps.on,91.52.158.122:42354,Mon Oct  3 23:10:11 2022
+        # DNAT       tcp  --  anywhere             anywhere             tcp dpts:11750:11759 to:10.1.6.190
+        self.assertEqual(str(NodeInfo("1.176.aps.on", IPv4Address("10.1.0.0"), IPv6Address("2001:db8::"))),
+            "NodeInfo(ipv4_address='10.1.6.190', ipv6_address='2001:db8::1:1:b0:0', port_first=11750, port_last=11759)")
+        
+        # 10.1.20.22,3.6.aps.on,62.214.245.132:39189,Mon Oct  3 23:10:35 2022
+        # DNAT       udp  --  anywhere             anywhere             udp dpts:20250:20259 to:10.1.20.22
+        self.assertEqual(str(NodeInfo("3.6.aps.on", IPv4Address("10.1.0.0"), IPv6Address("2001:db8::"))),
+            "NodeInfo(ipv4_address='10.1.20.22', ipv6_address='2001:db8::1:3:6:0', port_first=20250, port_last=20259)")
+        
+
+if __name__ == "__main__":
+    unittest.main()

--- a/roles/python-module/tasks/main.yml
+++ b/roles/python-module/tasks/main.yml
@@ -1,7 +1,5 @@
+#TODO: pip Paket daraus machen, weil dann keine Abhaengigkeit von Python Minor-Version.
 - name: kopiere opennet-Python-Module
   copy:
     src: "opennet/"
-    dest: "/usr/local/lib/python2.7/dist-packages/opennet/"
-
-- name: Abhaengigkeiten der python-Module installieren
-  apt: pkg=python-ipaddr state=present
+    dest: "/usr/local/lib/python3.7/dist-packages/opennet/"


### PR DESCRIPTION
* Migration Pyton 2.7 -> Python 3.7
* Migration iptables (Debian 9) -> iptables-legacy (Debian 10)