### PR TITLE
Activate new CA for gateways

### DIFF
--- a/roles/gateway-server/files/openvpn/opennet_ugw/ca.crt
+++ b/roles/gateway-server/files/openvpn/opennet_ugw/ca.crt
@@ -1,101 +1,10 @@
-Certificate:
-    Data:
-        Version: 3 (0x2)
-        Serial Number:
-            34:90:eb:db:a1:eb:13:35
-        Signature Algorithm: sha256WithRSAEncryption
-        Issuer: C=DE, ST=Mecklenburg-Vorpommern, O=Opennet Initiative e.V., OU=Opennet CA, CN=opennet-root.ca.on/emailAddress=admin@opennet-initiative.de
-        Validity
-            Not Before: Dec 22 00:00:00 2013 GMT
-            Not After : Dec 21 23:59:59 2023 GMT
-        Subject: C=DE, ST=Mecklenburg-Vorpommern, O=Opennet Initiative e.V., OU=Opennet CA, CN=opennet-vpn-ugw.ca.on/emailAddress=admin@opennet-initiative.de
-        Subject Public Key Info:
-            Public Key Algorithm: rsaEncryption
-            RSA Public Key: (2048 bit)
-                Modulus (2048 bit):
-                    00:b3:88:11:98:a6:df:47:49:30:bd:ed:69:f0:ad:
-                    fa:c3:06:46:bd:d8:d9:ac:9f:49:d5:94:03:9b:ea:
-                    f7:70:06:14:91:52:52:46:87:53:fd:a9:3d:d8:c7:
-                    98:5c:17:01:8f:47:3f:f0:9b:03:1e:66:06:97:65:
-                    61:50:fc:7f:f8:87:0c:e2:19:8a:21:6c:58:fb:6a:
-                    6e:75:d8:16:cf:a2:29:b8:4c:25:83:54:4c:d0:2c:
-                    91:c0:13:80:cd:0c:f1:1a:98:db:46:a7:3b:06:96:
-                    21:82:08:a0:0d:7d:c9:c1:a5:6c:83:2c:a7:08:2e:
-                    89:6c:b2:50:8e:00:a9:75:9e:10:b3:29:a3:1d:e4:
-                    23:30:38:03:b6:42:37:d6:a8:bc:13:bd:e6:b5:78:
-                    6b:15:4e:16:03:5e:95:b4:12:a2:bf:24:88:28:08:
-                    f5:0b:04:84:be:4e:10:49:25:23:c7:ca:55:0e:68:
-                    d7:72:73:f2:a8:9c:37:69:56:4e:b9:f6:ac:17:a0:
-                    94:c7:0d:13:06:74:13:b6:7e:60:51:e9:f3:87:ee:
-                    1c:f1:55:4d:ca:d4:da:86:cd:03:72:c0:13:53:5a:
-                    ae:64:bb:cf:50:b8:43:bf:f7:50:21:45:13:02:a9:
-                    9e:e1:ae:12:b4:a9:24:a4:bf:b6:3a:cf:a5:95:76:
-                    26:67
-                Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: critical
-                CA:TRUE
-            X509v3 Key Usage: 
-                Certificate Sign, CRL Sign
-            X509v3 CRL Distribution Points: 
-                URI:http://ca.opennet-initiative.de/vpnugw.crl
-
-            Netscape Cert Type: 
-                SSL CA, S/MIME CA, Object Signing CA
-            Netscape Base Url: 
-                http://ca.opennet-initiative.de/
-            Netscape Revocation Url: 
-                http://ca.opennet-initiative.de/vpnugw.crl
-            Netscape CA Revocation Url: 
-                http://ca.opennet-initiative.de/vpnugw.crl
-            Netscape CA Policy Url: 
-                http://ca.opennet-initiative.de/
-            Netscape Comment: 
-                Opennet VPN UGW CA
-            X509v3 Subject Key Identifier: 
-                C1:1F:4F:E4:A7:49:65:4B:0E:F8:E4:65:16:E2:28:76:49:A2:68:3B
-            X509v3 Authority Key Identifier: 
-                keyid:FA:DA:A6:25:24:2C:20:E7:E5:A3:5F:2F:9F:6B:C1:EA:19:1A:F8:C1
-                DirName:/C=DE/ST=Mecklenburg-Vorpommern/O=Opennet Initiative e.V./OU=Opennet CA/CN=opennet-root.ca.on/emailAddress=admin@opennet-initiative.de
-                serial:D0:94:11:CA:45:BA:B5:F1
-
-    Signature Algorithm: sha256WithRSAEncryption
-        48:71:67:27:95:6b:de:6e:d9:d7:d5:d8:1a:fd:b3:0e:c9:98:
-        48:09:08:22:b5:dd:68:a2:b1:23:cc:e1:05:2c:d6:30:db:8b:
-        c4:fc:76:32:b2:3c:09:4d:94:3b:33:1a:fe:bb:23:bc:af:fb:
-        52:e8:7e:4b:3b:d4:8c:21:40:49:6f:19:ad:64:01:91:43:79:
-        6b:91:0f:e3:78:c1:be:e3:83:82:83:13:ce:50:f3:60:9b:e1:
-        6c:1e:a9:82:87:29:79:f3:f6:61:06:15:ad:a0:1f:4d:af:c2:
-        c4:3a:ff:f5:2a:f2:a9:cf:db:b8:22:56:92:9a:e2:b4:3f:b1:
-        6e:1e:aa:d6:c0:69:8e:37:ae:c7:7e:26:55:a1:81:87:30:ca:
-        6d:84:cc:f5:69:0d:c3:94:59:c9:3a:89:66:60:be:72:4b:99:
-        b6:82:4b:4b:1a:5c:8b:43:dc:eb:30:34:94:d1:96:63:f6:9c:
-        5e:05:00:f4:ac:e0:a3:72:a2:5c:d6:64:31:67:cb:c7:d7:e9:
-        7d:c7:11:0e:93:16:a1:27:1b:b4:ee:98:a7:15:89:e9:66:ec:
-        fc:a6:28:bb:b7:d3:6b:d9:70:96:21:87:b2:50:82:b1:10:3a:
-        df:0e:b1:f2:88:cc:7e:d8:91:ae:db:43:06:16:43:b7:e0:cf:
-        dd:4e:da:71:f6:95:fd:16:aa:95:80:7b:7d:40:89:1c:47:9b:
-        1a:a0:8e:dc:31:51:30:cd:dc:9f:b9:44:d9:73:d7:6d:1d:b7:
-        a6:2e:66:40:ab:b8:a6:c9:2c:bd:5a:c7:15:f6:d8:47:21:8f:
-        50:5f:bd:f2:96:a3:5f:66:27:14:05:7c:a8:dd:94:89:de:ef:
-        e3:fc:6a:8a:e5:5b:52:22:61:7b:2a:74:06:7b:0f:4e:bf:33:
-        5c:cd:8d:4a:fa:3e:1a:e7:a0:39:c5:b3:7f:80:e1:67:40:59:
-        7e:32:a3:a6:4f:d1:48:6f:0e:c3:4a:ea:4d:52:c1:74:3c:27:
-        64:d1:cd:0a:6d:98:7d:f6:36:2b:61:a2:13:4f:cc:72:47:cd:
-        eb:82:8f:0b:90:cb:4e:c9:95:7c:e6:36:55:07:aa:92:86:7d:
-        88:7c:2b:f5:d1:1f:24:39:da:21:42:d7:5b:88:cb:76:3f:e0:
-        ba:12:c3:77:ae:1b:6e:bf:2f:e8:ff:4a:4a:ab:1e:c5:bc:da:
-        9d:1c:2e:6c:35:fd:d1:fe:b1:4c:3a:74:79:2b:7f:ac:77:33:
-        0f:ca:ca:fa:2a:8d:2b:29:ac:00:cf:29:f9:44:26:65:1d:3d:
-        29:37:47:8f:bf:aa:03:26:bd:37:8f:e9:e7:a6:6c:4a:04:7d:
-        45:e2:89:ef:0c:c0:f7:76
 -----BEGIN CERTIFICATE-----
-MIIHVzCCBT+gAwIBAgIINJDr26HrEzUwDQYJKoZIhvcNAQELBQAwga4xCzAJBgNV
+MIIHVzCCBT+gAwIBAgIIPV4icOEeX4owDQYJKoZIhvcNAQELBQAwga4xCzAJBgNV
 BAYTAkRFMR8wHQYDVQQIExZNZWNrbGVuYnVyZy1Wb3Jwb21tZXJuMSAwHgYDVQQK
 ExdPcGVubmV0IEluaXRpYXRpdmUgZS5WLjETMBEGA1UECxMKT3Blbm5ldCBDQTEb
 MBkGA1UEAxMSb3Blbm5ldC1yb290LmNhLm9uMSowKAYJKoZIhvcNAQkBFhthZG1p
-bkBvcGVubmV0LWluaXRpYXRpdmUuZGUwHhcNMTMxMjIyMDAwMDAwWhcNMjMxMjIx
-MjM1OTU5WjCBsTELMAkGA1UEBhMCREUxHzAdBgNVBAgTFk1lY2tsZW5idXJnLVZv
+bkBvcGVubmV0LWluaXRpYXRpdmUuZGUwHhcNMjIxMTI0MTYyNDAwWhcNMzIxMTI0
+MTYyNDAwWjCBsTELMAkGA1UEBhMCREUxHzAdBgNVBAgTFk1lY2tsZW5idXJnLVZv
 cnBvbW1lcm4xIDAeBgNVBAoTF09wZW5uZXQgSW5pdGlhdGl2ZSBlLlYuMRMwEQYD
 VQQLEwpPcGVubmV0IENBMR4wHAYDVQQDExVvcGVubmV0LXZwbi11Z3cuY2Eub24x
 KjAoBgkqhkiG9w0BCQEWG2FkbWluQG9wZW5uZXQtaW5pdGlhdGl2ZS5kZTCCASIw
@@ -118,129 +27,26 @@ IQYJYIZIAYb4QgENBBQWEk9wZW5uZXQgVlBOIFVHVyBDQTAdBgNVHQ4EFgQUwR9P
 Zy1Wb3Jwb21tZXJuMSAwHgYDVQQKExdPcGVubmV0IEluaXRpYXRpdmUgZS5WLjET
 MBEGA1UECxMKT3Blbm5ldCBDQTEbMBkGA1UEAxMSb3Blbm5ldC1yb290LmNhLm9u
 MSowKAYJKoZIhvcNAQkBFhthZG1pbkBvcGVubmV0LWluaXRpYXRpdmUuZGWCCQDQ
-lBHKRbq18TANBgkqhkiG9w0BAQsFAAOCAgEASHFnJ5Vr3m7Z19XYGv2zDsmYSAkI
-IrXdaKKxI8zhBSzWMNuLxPx2MrI8CU2UOzMa/rsjvK/7Uuh+SzvUjCFASW8ZrWQB
-kUN5a5EP43jBvuODgoMTzlDzYJvhbB6pgocpefP2YQYVraAfTa/CxDr/9Sryqc/b
-uCJWkpritD+xbh6q1sBpjjeux34mVaGBhzDKbYTM9WkNw5RZyTqJZmC+ckuZtoJL
-Sxpci0Pc6zA0lNGWY/acXgUA9Kzgo3KiXNZkMWfLx9fpfccRDpMWoScbtO6YpxWJ
-6Wbs/KYou7fTa9lwliGHslCCsRA63w6x8ojMftiRrttDBhZDt+DP3U7acfaV/Raq
-lYB7fUCJHEebGqCO3DFRMM3cn7lE2XPXbR23pi5mQKu4psksvVrHFfbYRyGPUF+9
-8pajX2YnFAV8qN2Uid7v4/xqiuVbUiJheyp0BnsPTr8zXM2NSvo+GuegOcWzf4Dh
-Z0BZfjKjpk/RSG8Ow0rqTVLBdDwnZNHNCm2YffY2K2GiE0/MckfN64KPC5DLTsmV
-fOY2VQeqkoZ9iHwr9dEfJDnaIULXW4jLdj/guhLDd64bbr8v6P9KSqsexbzanRwu
-bDX90f6xTDp0eSt/rHczD8rK+iqNKymsAM8p+UQmZR09KTdHj7+qAya9N4/p56Zs
-SgR9ReKJ7wzA93Y=
+lBHKRbq18TANBgkqhkiG9w0BAQsFAAOCAgEAniiVGXOIEZQL5MtUOBVKTh1bjeja
+XFLErMdxTi56MtypW8iPQUXsBaGJ/EKgw0bi3/96+s27zPMLllDDs4GK+BgmelpP
+KOwsEp/GB2Nb43jw8aC5snHH7nXnpPKIHLN6C/axQmoOC0UPWncOwv1w/teQ6ylq
+eGFqB1FqQaUwLmjQhHlSfFciKIbw3ahk9sEoMD3pvEIknT8Psw+l/2ywxAIda5Ex
+pqDmSDIw8Ofbsw++mpuUZBS7QHhTQGLHS06SV/7mgUQuM90IZs+ix0B/Lz1FTqZA
+ZdXK+ytZ78t17w7anUAtniI07Cm1jr2VkuXpCPjhNWIXGSWQgutwz59psHSb/GvL
+eiqR2lYGoaQJ5Jd7N5o/893xoEeWLUtPeU8HH3qLuf22b2bz+evFrTCWfvB7MGHS
+WLlbc5QsvlKdw7/7KO4JOrsmVaZWFeDbxROINEz3dzEGe0g6V3xYm2zAShyWrRiv
+XhKM70sb5tFV7+QBYOAQ2vU5ULBxjMowm/AMKdGeaAEnvI3zPFttfz/g1RrLom5M
+o8AsBKXmqYd9/kfS9EmGx2pNpGvzUJBjm324sLJG4t64iZ6B/rNfNFj8Y052dZRG
+vUWU1Jr//rYJolJMZ2sABV+jv9bAaQLlrOyizxh5tgPku1VYIsvhMEvjobHOj9YF
+vDEK2KtPVgUYebE=
 -----END CERTIFICATE-----
-Certificate:
-    Data:
-        Version: 3 (0x2)
-        Serial Number:
-            d0:94:11:ca:45:ba:b5:f1
-        Signature Algorithm: sha512WithRSAEncryption
-        Issuer: C=DE, ST=Mecklenburg-Vorpommern, O=Opennet Initiative e.V., OU=Opennet CA, CN=opennet-root.ca.on/emailAddress=admin@opennet-initiative.de
-        Validity
-            Not Before: Dec 22 00:00:00 2013 GMT
-            Not After : Dec 21 23:59:59 2033 GMT
-        Subject: C=DE, ST=Mecklenburg-Vorpommern, O=Opennet Initiative e.V., OU=Opennet CA, CN=opennet-root.ca.on/emailAddress=admin@opennet-initiative.de
-        Subject Public Key Info:
-            Public Key Algorithm: rsaEncryption
-            RSA Public Key: (4096 bit)
-                Modulus (4096 bit):
-                    00:d6:b7:ad:01:d9:5e:c6:d3:55:c5:93:1b:c8:62:
-                    82:07:a7:31:12:24:77:e5:5b:73:05:94:96:2b:cc:
-                    41:6b:b9:45:38:89:c5:e7:1c:72:58:1f:39:5f:19:
-                    1e:31:88:c2:8b:9a:71:2e:c8:67:dd:c7:92:bb:ad:
-                    cf:03:4c:83:5b:4a:dd:ec:8d:72:5a:d0:7f:f9:d3:
-                    5e:41:b1:a8:83:3c:5f:27:22:b4:78:2a:77:77:0f:
-                    4e:cb:8b:e6:cd:2c:e7:08:1b:82:3a:52:38:11:62:
-                    9a:96:a6:ae:63:45:be:ab:35:24:86:e5:4d:59:72:
-                    d3:c8:eb:4b:41:f1:43:a4:07:a6:21:0b:1f:44:4e:
-                    34:69:ef:8c:27:9e:60:be:58:53:94:46:2d:9b:bf:
-                    2e:33:8e:50:7a:cd:ee:ab:d2:27:34:df:75:0b:96:
-                    6c:33:30:f0:ec:0d:9a:98:85:35:ad:42:ec:ff:86:
-                    f6:fe:38:a7:8c:30:b9:2a:b2:47:74:3f:cc:7e:e0:
-                    6a:d1:90:93:7c:8d:fb:8a:50:1b:78:08:2a:c1:0d:
-                    ad:04:a9:fd:4f:39:15:0a:ac:61:87:37:de:61:78:
-                    19:80:f8:23:22:be:95:01:0c:ab:50:f6:72:0a:eb:
-                    38:f2:f4:30:e9:8f:7b:c6:02:3d:4d:fe:0a:15:9a:
-                    18:b8:71:e8:d8:be:fc:31:39:aa:f6:76:20:7a:16:
-                    91:8a:55:a3:55:1c:00:4e:fc:8d:ae:1d:6e:39:5c:
-                    58:ae:a2:90:86:74:fd:e3:18:7f:04:ee:9e:23:89:
-                    cc:75:91:42:93:68:15:9b:03:7e:a0:86:9a:54:74:
-                    e6:54:b5:16:b5:ff:b7:e5:c5:f0:0f:a2:74:63:83:
-                    80:ce:91:c0:f2:7f:cf:e5:ca:cf:80:fc:ac:ac:12:
-                    f7:61:87:6a:7b:c5:68:f8:f5:93:50:0e:12:44:b4:
-                    4d:db:d3:e1:0f:b4:65:10:55:6c:98:8d:09:03:5c:
-                    06:1f:08:31:16:c8:ca:b6:51:4f:72:c1:0b:38:45:
-                    fc:d0:81:8f:fc:1e:42:83:d7:41:2a:46:72:09:62:
-                    41:60:ad:b2:de:9e:0c:18:17:bb:b2:ae:e6:ca:74:
-                    10:06:87:c1:f7:e4:b3:9f:d9:a0:32:bb:86:a5:e9:
-                    97:7c:c0:8d:45:e4:57:69:93:a1:15:ed:21:6b:aa:
-                    c3:5e:bc:33:fd:ad:b5:86:ff:da:15:45:5e:ee:85:
-                    28:1e:2f:c1:1b:b8:5d:e0:dd:ed:a2:2d:60:c9:8b:
-                    87:71:b9:87:42:8d:bb:39:a0:5f:f2:42:36:96:7d:
-                    60:80:f6:f8:85:c4:61:ca:e6:67:8a:39:dd:99:74:
-                    58:47:51
-                Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: critical
-                CA:TRUE
-            X509v3 Subject Key Identifier: 
-                FA:DA:A6:25:24:2C:20:E7:E5:A3:5F:2F:9F:6B:C1:EA:19:1A:F8:C1
-            X509v3 Key Usage: 
-                Certificate Sign, CRL Sign
-            X509v3 CRL Distribution Points: 
-                URI:http://ca.opennet-initiative.de/root.crl
-
-            Netscape Cert Type: 
-                SSL CA, S/MIME CA, Object Signing CA
-            Netscape Base Url: 
-                http://ca.opennet-initiative.de/
-            Netscape Revocation Url: 
-                http://ca.opennet-initiative.de/root.crl
-            Netscape CA Revocation Url: 
-                http://ca.opennet-initiative.de/root.crl
-            Netscape CA Policy Url: 
-                http://ca.opennet-initiative.de/
-            Netscape Comment: 
-                Opennet Root CA
-    Signature Algorithm: sha512WithRSAEncryption
-        05:cf:01:9d:3a:ac:b6:a6:70:8c:72:57:66:da:97:ed:d6:f7:
-        b2:24:9c:ce:75:5a:0d:db:26:86:fb:f5:2f:b3:08:b3:b2:c7:
-        e2:77:5f:9b:61:1b:8c:12:7c:ee:e0:d1:51:f1:59:7f:66:4c:
-        d3:c4:f0:06:d4:45:12:71:78:15:5e:75:d9:61:c5:fc:a7:10:
-        8b:48:44:1a:a7:9e:80:ee:30:d6:3c:a2:1b:68:c7:ac:77:78:
-        c6:d3:70:67:6a:d0:f8:80:0e:7b:8f:d9:a3:3c:75:6a:eb:f3:
-        8e:77:83:d8:d0:a8:c6:49:b4:09:a5:47:14:d2:31:5f:3b:fd:
-        a5:fa:c2:78:80:0c:b4:a0:f6:6e:27:5e:49:f1:43:d8:72:18:
-        af:9d:23:a1:b0:ea:63:06:6e:59:ed:06:4b:93:a4:bb:a3:4a:
-        36:f3:b8:5b:f9:dc:00:ec:49:46:c2:51:5b:da:e0:64:0e:71:
-        22:7b:4b:f5:8b:a0:98:c3:c2:c0:e4:3e:f5:11:99:6c:3f:1f:
-        64:51:7f:c5:2b:e6:8f:8f:84:20:f9:52:bc:b7:74:63:ee:c5:
-        75:cc:7f:5c:91:6a:e6:5f:21:4c:df:3e:cc:75:b0:80:15:84:
-        92:f7:02:52:c6:0f:10:f4:2a:75:64:d2:2b:64:c3:32:42:4b:
-        2b:6d:90:1f:6a:cf:ee:69:20:70:30:27:7b:3b:ac:cf:e5:f3:
-        37:cb:2c:29:d4:9d:3d:49:3f:3f:e2:75:33:f0:d8:41:24:c2:
-        c1:4b:6c:05:92:9c:ad:84:77:04:63:86:5a:05:b6:82:92:45:
-        b6:a6:02:8c:4c:fc:ee:e0:90:d2:a2:b3:e6:74:f5:88:7e:8a:
-        05:35:8b:af:24:39:bd:7e:ef:4a:9d:30:7a:cb:94:dc:c7:42:
-        ef:99:e2:74:03:0c:44:80:97:da:f6:75:68:1e:67:2a:3d:d2:
-        cc:e0:98:2a:cb:fb:15:c6:f6:83:9f:b9:20:74:fc:db:38:8d:
-        c3:94:a4:bb:71:ea:4c:1f:61:d3:4d:d6:a3:35:dd:41:cb:f8:
-        70:97:ee:4c:ac:82:be:10:c1:17:59:1a:44:7d:76:91:aa:91:
-        7e:48:79:3d:0d:d6:98:d9:e4:8f:76:89:fa:61:ec:de:a6:9b:
-        7e:85:d0:88:16:2e:82:fa:1e:4b:82:3c:e3:01:c6:5e:fa:29:
-        b3:1e:e8:a7:14:82:2f:69:93:da:02:93:12:50:44:01:cd:5a:
-        3e:1b:e2:c4:2b:22:51:3b:62:c4:e1:1e:d4:71:8d:c8:63:7f:
-        9f:bd:ce:00:43:76:d3:99:e5:c3:7d:32:03:ae:44:a5:ca:3e:
-        b9:01:c8:4c:02:c8:e4:55
 -----BEGIN CERTIFICATE-----
 MIIHZjCCBU6gAwIBAgIJANCUEcpFurXxMA0GCSqGSIb3DQEBDQUAMIGuMQswCQYD
 VQQGEwJERTEfMB0GA1UECBMWTWVja2xlbmJ1cmctVm9ycG9tbWVybjEgMB4GA1UE
 ChMXT3Blbm5ldCBJbml0aWF0aXZlIGUuVi4xEzARBgNVBAsTCk9wZW5uZXQgQ0Ex
 GzAZBgNVBAMTEm9wZW5uZXQtcm9vdC5jYS5vbjEqMCgGCSqGSIb3DQEJARYbYWRt
-aW5Ab3Blbm5ldC1pbml0aWF0aXZlLmRlMB4XDTEzMTIyMjAwMDAwMFoXDTMzMTIy
-MTIzNTk1OVowga4xCzAJBgNVBAYTAkRFMR8wHQYDVQQIExZNZWNrbGVuYnVyZy1W
+aW5Ab3Blbm5ldC1pbml0aWF0aXZlLmRlMB4XDTIzMDcwOTAwMDAwMFoXDTM4MDcw
+ODIzNTk1OVowga4xCzAJBgNVBAYTAkRFMR8wHQYDVQQIExZNZWNrbGVuYnVyZy1W
 b3Jwb21tZXJuMSAwHgYDVQQKExdPcGVubmV0IEluaXRpYXRpdmUgZS5WLjETMBEG
 A1UECxMKT3Blbm5ldCBDQTEbMBkGA1UEAxMSb3Blbm5ldC1yb290LmNhLm9uMSow
 KAYJKoZIhvcNAQkBFhthZG1pbkBvcGVubmV0LWluaXRpYXRpdmUuZGUwggIiMA0G
@@ -263,16 +69,16 @@ bm5ldC1pbml0aWF0aXZlLmRlLzA3BglghkgBhvhCAQMEKhYoaHR0cDovL2NhLm9w
 ZW5uZXQtaW5pdGlhdGl2ZS5kZS9yb290LmNybDA3BglghkgBhvhCAQQEKhYoaHR0
 cDovL2NhLm9wZW5uZXQtaW5pdGlhdGl2ZS5kZS9yb290LmNybDAvBglghkgBhvhC
 AQgEIhYgaHR0cDovL2NhLm9wZW5uZXQtaW5pdGlhdGl2ZS5kZS8wHgYJYIZIAYb4
-QgENBBEWD09wZW5uZXQgUm9vdCBDQTANBgkqhkiG9w0BAQ0FAAOCAgEABc8BnTqs
-tqZwjHJXZtqX7db3siScznVaDdsmhvv1L7MIs7LH4ndfm2EbjBJ87uDRUfFZf2ZM
-08TwBtRFEnF4FV512WHF/KcQi0hEGqeegO4w1jyiG2jHrHd4xtNwZ2rQ+IAOe4/Z
-ozx1auvzjneD2NCoxkm0CaVHFNIxXzv9pfrCeIAMtKD2bideSfFD2HIYr50jobDq
-YwZuWe0GS5Oku6NKNvO4W/ncAOxJRsJRW9rgZA5xIntL9YugmMPCwOQ+9RGZbD8f
-ZFF/xSvmj4+EIPlSvLd0Y+7Fdcx/XJFq5l8hTN8+zHWwgBWEkvcCUsYPEPQqdWTS
-K2TDMkJLK22QH2rP7mkgcDAnezusz+XzN8ssKdSdPUk/P+J1M/DYQSTCwUtsBZKc
-rYR3BGOGWgW2gpJFtqYCjEz87uCQ0qKz5nT1iH6KBTWLryQ5vX7vSp0wesuU3MdC
-75nidAMMRICX2vZ1aB5nKj3SzOCYKsv7Fcb2g5+5IHT82ziNw5Sku3HqTB9h003W
-ozXdQcv4cJfuTKyCvhDBF1kaRH12kaqRfkh5PQ3WmNnkj3aJ+mHs3qabfoXQiBYu
-gvoeS4I84wHGXvopsx7opxSCL2mT2gKTElBEAc1aPhvixCsiUTtixOEe1HGNyGN/
-n73OAEN205nlw30yA65Epco+uQHITALI5FU=
+QgENBBEWD09wZW5uZXQgUm9vdCBDQTANBgkqhkiG9w0BAQ0FAAOCAgEAVslwTTfv
+v0d5SMuNwQzFZaAtu57hHuOo6nYVGX4SrWpJFOUX1lq9qgc9DOgfydX4zPm367uV
+FfZBNzY/EuM3zsJ6I9GhNcJTx3Lxao9t8dRDIe2JEcwwX2uo47q88AN1+lqTc3G1
+42rvrdZFULx77xfXMhgXGTm/wAwbc2oRH5JlDNOGN4fzeShDDOrTAZLRfFMW3uMa
+qQpFiHZpQYoZp45BAQmoLKhKjMdrLyswc58NL1WT4VVlusGDTlaLADF1Vuw2oW7D
+I9GckmP38v0XCQryMSNwPvKWxsiEtFIT+iUimf7DzNAnk+BZwEwIs9/9EnNLgtaJ
+XsNdmmM6MmVz5ymUEzbo6jPxi8LNl94nEO50LLtyH0dup8TbPlho4hR2lX2jJErs
+nxKh+bXpmwrVpcvNYAMgBtWPaXykbrEgFeUg96YT5/G2FuXSlVZRwYqxQ5oKKCpZ
+0YNhHYpSV0KBHdzJrzJVWed6/dsWvC7HLb8FShaAv+PRBC1pzsax2TZ2WZv5yeX1
+C6c1VGJd4H97/iTQgQxANSEU1qezA8C0s/vWlfyYrpeIyIlIJwT9MlMBvwnAKFtj
+1WdJqp8IQH2ntvDPrUAGIeNbx6BAt0O4xa/6yls92rN1tM/dyBBZ9MpQEeJG+nWJ
+X4D+WJ879onydKgJEIBQHpdn2ERLDCkOeU0=
 -----END CERTIFICATE-----

--- a/roles/gateway-server/files/openvpn/opennet_users/ca.crt
+++ b/roles/gateway-server/files/openvpn/opennet_users/ca.crt
@@ -1,246 +1,52 @@
-Certificate:
-    Data:
-        Version: 3 (0x2)
-        Serial Number:
-            f0:66:e8:b1:6d:bd:39:5f
-        Signature Algorithm: sha256WithRSAEncryption
-        Issuer: C=DE, ST=Mecklenburg-Vorpommern, O=Opennet Initiative e.V., OU=Opennet CA, CN=opennet-root.ca.on/emailAddress=admin@opennet-initiative.de
-        Validity
-            Not Before: Dec 22 00:00:00 2013 GMT
-            Not After : Dec 21 23:59:59 2023 GMT
-        Subject: C=DE, ST=Mecklenburg-Vorpommern, O=Opennet Initiative e.V., OU=Opennet CA, CN=opennet-vpn-user.ca.on/emailAddress=admin@opennet-initiative.de
-        Subject Public Key Info:
-            Public Key Algorithm: rsaEncryption
-            RSA Public Key: (2048 bit)
-                Modulus (2048 bit):
-                    00:bb:8b:1d:ab:4d:d8:ad:1d:38:5f:8e:ae:f6:9c:
-                    e1:91:07:3d:e2:c1:81:9f:01:48:a6:0c:0e:fa:15:
-                    e6:60:0e:8b:ec:6d:50:88:cd:21:c7:fb:dc:01:28:
-                    65:4a:7e:f5:c5:d5:80:0a:4a:c8:6d:4d:bf:04:3a:
-                    92:cd:0d:7a:ca:b3:48:73:34:19:33:f9:4a:52:8f:
-                    f8:aa:39:13:8d:df:47:3b:cf:0b:be:ef:17:67:ea:
-                    66:86:47:8b:b5:72:7b:56:77:93:3c:d6:68:86:6e:
-                    6c:8b:c9:a4:89:59:bd:bb:c4:fe:4b:76:35:95:83:
-                    05:12:df:5a:c1:17:0f:89:e4:c7:da:0b:f1:7c:b2:
-                    fd:d2:b9:77:1f:55:a0:ad:3c:d6:63:fe:7e:fe:e3:
-                    79:a3:e7:f3:e9:21:08:11:9b:50:67:35:19:f3:3f:
-                    98:d6:d7:84:41:06:7a:1b:03:d5:c9:7e:5c:a8:e1:
-                    66:12:32:e3:be:6e:7a:2a:ac:92:51:5d:32:2b:25:
-                    74:ed:a1:45:d3:a3:14:69:6d:62:a9:12:85:5e:f8:
-                    8a:0e:9d:f5:96:f3:51:51:61:95:88:72:bb:6e:ee:
-                    82:e9:60:59:1f:1a:61:6e:da:e2:de:42:1a:95:da:
-                    17:d5:0a:c2:83:46:e5:ce:a2:ac:e2:21:5a:29:53:
-                    12:ed
-                Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: critical
-                CA:TRUE
-            X509v3 Key Usage: 
-                Certificate Sign, CRL Sign
-            X509v3 CRL Distribution Points: 
-                URI:http://ca.opennet-initiative.de/vpnuser.crl
-
-            Netscape Cert Type: 
-                SSL CA, S/MIME CA, Object Signing CA
-            Netscape Base Url: 
-                http://ca.opennet-initiative.de/
-            Netscape Revocation Url: 
-                http://ca.opennet-initiative.de/vpnuser.crl
-            Netscape CA Revocation Url: 
-                http://ca.opennet-initiative.de/vpnuser.crl
-            Netscape CA Policy Url: 
-                http://ca.opennet-initiative.de/
-            Netscape Comment: 
-                Opennet VPN User CA
-            X509v3 Subject Key Identifier: 
-                FA:75:C4:8D:8A:AA:D1:81:E1:29:15:A6:B4:55:E3:C0:32:05:F6:C7
-            X509v3 Authority Key Identifier: 
-                keyid:FA:DA:A6:25:24:2C:20:E7:E5:A3:5F:2F:9F:6B:C1:EA:19:1A:F8:C1
-                DirName:/C=DE/ST=Mecklenburg-Vorpommern/O=Opennet Initiative e.V./OU=Opennet CA/CN=opennet-root.ca.on/emailAddress=admin@opennet-initiative.de
-                serial:D0:94:11:CA:45:BA:B5:F1
-
-    Signature Algorithm: sha256WithRSAEncryption
-        7f:55:77:96:ec:90:7f:2e:e6:1b:cf:f4:a4:3a:3d:7f:2f:de:
-        7a:4b:4f:57:b9:cb:e1:a8:7a:e1:05:70:f1:0b:0f:70:bb:35:
-        84:f3:3e:5c:c9:63:5e:ef:42:f5:ea:94:9d:2b:f0:ae:a3:a7:
-        15:00:b4:90:90:3a:47:ac:8c:5e:c4:1d:23:f1:c2:6b:b8:a0:
-        9c:41:ff:c5:f0:fc:e4:db:67:b6:13:83:6d:c3:00:36:08:44:
-        b3:34:4d:b6:51:e1:d5:c1:61:ad:25:49:dd:68:84:53:f1:e7:
-        e7:93:17:01:49:c8:c0:3d:f5:43:bf:e0:94:1d:3f:90:d1:f1:
-        54:19:1d:a4:ea:82:b8:72:48:93:41:b2:0d:11:ca:50:0c:5f:
-        81:ff:c2:e2:be:e1:3d:c8:52:c6:68:6d:9b:97:e1:30:1b:d5:
-        88:33:31:37:f6:c2:19:27:6d:e0:c9:00:69:06:1a:d3:91:bb:
-        a1:a5:a1:7d:f5:b6:c0:d8:b3:71:6a:c5:ac:af:5e:be:ce:18:
-        6c:60:9d:a8:94:66:40:96:87:d6:18:a0:58:43:ac:7a:43:d3:
-        a5:57:41:de:c4:8c:67:95:3b:12:b8:3c:0e:06:3a:ee:c1:33:
-        e8:70:ec:cf:d2:3f:67:0e:c2:ea:e4:0e:d3:1a:34:37:78:c7:
-        f2:84:4c:ee:0f:22:de:90:cf:17:fc:ce:be:c7:38:85:2f:ef:
-        73:3d:61:18:9a:e0:67:6a:16:57:78:c5:02:40:10:a3:d4:29:
-        62:74:6f:79:20:9c:f7:36:43:f9:7e:ee:b7:07:80:a5:25:f1:
-        c2:5d:e8:f6:a3:b2:52:24:f9:84:34:2d:79:0c:14:52:c4:63:
-        59:f7:b2:37:12:25:ec:3d:6a:bb:ca:47:05:c7:83:8a:d9:bd:
-        94:16:c8:45:72:94:32:41:c9:28:86:72:88:f1:6c:02:a9:06:
-        59:4d:a8:17:8b:17:73:24:6a:c6:c0:62:e5:22:a4:d3:78:be:
-        75:b7:5e:b9:18:a4:2f:41:4f:13:90:01:6b:19:ed:df:7d:f4:
-        b6:47:76:d5:23:00:02:68:db:49:21:2f:c9:b0:c0:ca:fb:04:
-        c7:b7:bc:7d:a9:55:98:6a:ca:fe:f1:48:e4:9a:f5:b8:5b:6a:
-        ce:d0:f9:f0:84:f9:01:49:31:d0:e0:eb:bb:62:34:3b:d3:34:
-        a3:2c:6c:aa:15:b0:62:3d:66:0c:6c:ad:72:df:e4:75:dd:9f:
-        a6:37:7b:43:95:8e:4b:88:fa:c3:80:91:f7:03:6b:c0:58:10:
-        4a:a1:8b:79:1c:3a:96:82:eb:2b:86:37:7c:6a:0c:0e:b6:ef:
-        1c:19:8f:ed:f0:07:bc:fc
 -----BEGIN CERTIFICATE-----
-MIIHXTCCBUWgAwIBAgIJAPBm6LFtvTlfMA0GCSqGSIb3DQEBCwUAMIGuMQswCQYD
-VQQGEwJERTEfMB0GA1UECBMWTWVja2xlbmJ1cmctVm9ycG9tbWVybjEgMB4GA1UE
-ChMXT3Blbm5ldCBJbml0aWF0aXZlIGUuVi4xEzARBgNVBAsTCk9wZW5uZXQgQ0Ex
-GzAZBgNVBAMTEm9wZW5uZXQtcm9vdC5jYS5vbjEqMCgGCSqGSIb3DQEJARYbYWRt
-aW5Ab3Blbm5ldC1pbml0aWF0aXZlLmRlMB4XDTEzMTIyMjAwMDAwMFoXDTIzMTIy
-MTIzNTk1OVowgbIxCzAJBgNVBAYTAkRFMR8wHQYDVQQIExZNZWNrbGVuYnVyZy1W
-b3Jwb21tZXJuMSAwHgYDVQQKExdPcGVubmV0IEluaXRpYXRpdmUgZS5WLjETMBEG
-A1UECxMKT3Blbm5ldCBDQTEfMB0GA1UEAxMWb3Blbm5ldC12cG4tdXNlci5jYS5v
-bjEqMCgGCSqGSIb3DQEJARYbYWRtaW5Ab3Blbm5ldC1pbml0aWF0aXZlLmRlMIIB
-IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu4sdq03YrR04X46u9pzhkQc9
-4sGBnwFIpgwO+hXmYA6L7G1QiM0hx/vcAShlSn71xdWACkrIbU2/BDqSzQ16yrNI
-czQZM/lKUo/4qjkTjd9HO88Lvu8XZ+pmhkeLtXJ7VneTPNZohm5si8mkiVm9u8T+
-S3Y1lYMFEt9awRcPieTH2gvxfLL90rl3H1WgrTzWY/5+/uN5o+fz6SEIEZtQZzUZ
-8z+Y1teEQQZ6GwPVyX5cqOFmEjLjvm56KqySUV0yKyV07aFF06MUaW1iqRKFXviK
-Dp31lvNRUWGViHK7bu6C6WBZHxphbtri3kIaldoX1QrCg0blzqKs4iFaKVMS7QID
-AQABo4ICdjCCAnIwDwYDVR0TAQH/BAUwAwEB/zALBgNVHQ8EBAMCAQYwPAYDVR0f
-BDUwMzAxoC+gLYYraHR0cDovL2NhLm9wZW5uZXQtaW5pdGlhdGl2ZS5kZS92cG51
-c2VyLmNybDARBglghkgBhvhCAQEEBAMCAAcwLwYJYIZIAYb4QgECBCIWIGh0dHA6
-Ly9jYS5vcGVubmV0LWluaXRpYXRpdmUuZGUvMDoGCWCGSAGG+EIBAwQtFitodHRw
-Oi8vY2Eub3Blbm5ldC1pbml0aWF0aXZlLmRlL3ZwbnVzZXIuY3JsMDoGCWCGSAGG
-+EIBBAQtFitodHRwOi8vY2Eub3Blbm5ldC1pbml0aWF0aXZlLmRlL3ZwbnVzZXIu
-Y3JsMC8GCWCGSAGG+EIBCAQiFiBodHRwOi8vY2Eub3Blbm5ldC1pbml0aWF0aXZl
-LmRlLzAiBglghkgBhvhCAQ0EFRYTT3Blbm5ldCBWUE4gVXNlciBDQTAdBgNVHQ4E
-FgQU+nXEjYqq0YHhKRWmtFXjwDIF9scwgeMGA1UdIwSB2zCB2IAU+tqmJSQsIOfl
-o18vn2vB6hka+MGhgbSkgbEwga4xCzAJBgNVBAYTAkRFMR8wHQYDVQQIExZNZWNr
-bGVuYnVyZy1Wb3Jwb21tZXJuMSAwHgYDVQQKExdPcGVubmV0IEluaXRpYXRpdmUg
-ZS5WLjETMBEGA1UECxMKT3Blbm5ldCBDQTEbMBkGA1UEAxMSb3Blbm5ldC1yb290
-LmNhLm9uMSowKAYJKoZIhvcNAQkBFhthZG1pbkBvcGVubmV0LWluaXRpYXRpdmUu
-ZGWCCQDQlBHKRbq18TANBgkqhkiG9w0BAQsFAAOCAgEAf1V3luyQfy7mG8/0pDo9
-fy/eektPV7nL4ah64QVw8QsPcLs1hPM+XMljXu9C9eqUnSvwrqOnFQC0kJA6R6yM
-XsQdI/HCa7ignEH/xfD85NtnthODbcMANghEszRNtlHh1cFhrSVJ3WiEU/Hn55MX
-AUnIwD31Q7/glB0/kNHxVBkdpOqCuHJIk0GyDRHKUAxfgf/C4r7hPchSxmhtm5fh
-MBvViDMxN/bCGSdt4MkAaQYa05G7oaWhffW2wNizcWrFrK9evs4YbGCdqJRmQJaH
-1higWEOsekPTpVdB3sSMZ5U7Erg8DgY67sEz6HDsz9I/Zw7C6uQO0xo0N3jH8oRM
-7g8i3pDPF/zOvsc4hS/vcz1hGJrgZ2oWV3jFAkAQo9QpYnRveSCc9zZD+X7utweA
-pSXxwl3o9qOyUiT5hDQteQwUUsRjWfeyNxIl7D1qu8pHBceDitm9lBbIRXKUMkHJ
-KIZyiPFsAqkGWU2oF4sXcyRqxsBi5SKk03i+dbdeuRikL0FPE5ABaxnt3330tkd2
-1SMAAmjbSSEvybDAyvsEx7e8falVmGrK/vFI5Jr1uFtqztD58IT5AUkx0ODru2I0
-O9M0oyxsqhWwYj1mDGytct/kdd2fpjd7Q5WOS4j6w4CR9wNrwFgQSqGLeRw6loLr
-K4Y3fGoMDrbvHBmP7fAHvPw=
+MIIHXDCCBUSgAwIBAgIIWgBI/pht68cwDQYJKoZIhvcNAQELBQAwga4xCzAJBgNV
+BAYTAkRFMR8wHQYDVQQIExZNZWNrbGVuYnVyZy1Wb3Jwb21tZXJuMSAwHgYDVQQK
+ExdPcGVubmV0IEluaXRpYXRpdmUgZS5WLjETMBEGA1UECxMKT3Blbm5ldCBDQTEb
+MBkGA1UEAxMSb3Blbm5ldC1yb290LmNhLm9uMSowKAYJKoZIhvcNAQkBFhthZG1p
+bkBvcGVubmV0LWluaXRpYXRpdmUuZGUwHhcNMjIxMTI0MTYyNTAwWhcNMzIxMTI0
+MTYyNTAwWjCBsjELMAkGA1UEBhMCREUxHzAdBgNVBAgTFk1lY2tsZW5idXJnLVZv
+cnBvbW1lcm4xIDAeBgNVBAoTF09wZW5uZXQgSW5pdGlhdGl2ZSBlLlYuMRMwEQYD
+VQQLEwpPcGVubmV0IENBMR8wHQYDVQQDExZvcGVubmV0LXZwbi11c2VyLmNhLm9u
+MSowKAYJKoZIhvcNAQkBFhthZG1pbkBvcGVubmV0LWluaXRpYXRpdmUuZGUwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC7ix2rTditHThfjq72nOGRBz3i
+wYGfAUimDA76FeZgDovsbVCIzSHH+9wBKGVKfvXF1YAKSshtTb8EOpLNDXrKs0hz
+NBkz+UpSj/iqORON30c7zwu+7xdn6maGR4u1cntWd5M81miGbmyLyaSJWb27xP5L
+djWVgwUS31rBFw+J5MfaC/F8sv3SuXcfVaCtPNZj/n7+43mj5/PpIQgRm1BnNRnz
+P5jW14RBBnobA9XJflyo4WYSMuO+bnoqrJJRXTIrJXTtoUXToxRpbWKpEoVe+IoO
+nfWW81FRYZWIcrtu7oLpYFkfGmFu2uLeQhqV2hfVCsKDRuXOoqziIVopUxLtAgMB
+AAGjggJ2MIICcjAPBgNVHRMBAf8EBTADAQH/MAsGA1UdDwQEAwIBBjA8BgNVHR8E
+NTAzMDGgL6AthitodHRwOi8vY2Eub3Blbm5ldC1pbml0aWF0aXZlLmRlL3ZwbnVz
+ZXIuY3JsMBEGCWCGSAGG+EIBAQQEAwIABzAvBglghkgBhvhCAQIEIhYgaHR0cDov
+L2NhLm9wZW5uZXQtaW5pdGlhdGl2ZS5kZS8wOgYJYIZIAYb4QgEDBC0WK2h0dHA6
+Ly9jYS5vcGVubmV0LWluaXRpYXRpdmUuZGUvdnBudXNlci5jcmwwOgYJYIZIAYb4
+QgEEBC0WK2h0dHA6Ly9jYS5vcGVubmV0LWluaXRpYXRpdmUuZGUvdnBudXNlci5j
+cmwwLwYJYIZIAYb4QgEIBCIWIGh0dHA6Ly9jYS5vcGVubmV0LWluaXRpYXRpdmUu
+ZGUvMCIGCWCGSAGG+EIBDQQVFhNPcGVubmV0IFZQTiBVc2VyIENBMB0GA1UdDgQW
+BBT6dcSNiqrRgeEpFaa0VePAMgX2xzCB4wYDVR0jBIHbMIHYgBT62qYlJCwg5+Wj
+Xy+fa8HqGRr4waGBtKSBsTCBrjELMAkGA1UEBhMCREUxHzAdBgNVBAgTFk1lY2ts
+ZW5idXJnLVZvcnBvbW1lcm4xIDAeBgNVBAoTF09wZW5uZXQgSW5pdGlhdGl2ZSBl
+LlYuMRMwEQYDVQQLEwpPcGVubmV0IENBMRswGQYDVQQDExJvcGVubmV0LXJvb3Qu
+Y2Eub24xKjAoBgkqhkiG9w0BCQEWG2FkbWluQG9wZW5uZXQtaW5pdGlhdGl2ZS5k
+ZYIJANCUEcpFurXxMA0GCSqGSIb3DQEBCwUAA4ICAQAVdP3BbaMWGE+O85D2ziep
+7p6P26Tit7O7nTHQ4dBuMkz+ELCIMc4W8Va4Pp+2GJ690yLHCc5VQN4FogXY511k
+rbCPoNZvcnSkNpkmrQ/Qr3iolHhKHCJKzlra70+GkuFfL+wj743Bq3ECTZrTNPES
+pRYCCBboC+ihhFq6/Eztqo9nNac+mEopmUwZv0+eVwuZlixL8pfVoFJfgilT5GH5
+Grycq4kt2UcyKZp/WVPJlyNnI4sjOAX+6HuL+I7NZIByvd+Gh4PZdoGP96MAhCJ0
+WKdCydQYnXLWtjaQAxm0etZop9AVkTTuPZJeJKAKNDy1w7376QkyXBxZnWNfZGaE
+lnb2tgT2C188JqUzSEVQIqAK702ZuLcyeZ0NFbHRT7CKu4driBOFJWij2RiSrF3I
+LDJDf3uLf9iV0G9U1vuZZoPUJMwOU+BX9IrC0qHdJri+skd2PbT3gn0rDAf6ZseW
+cYPM+BQ4l+7Obt4jUh4jF0JYoNIrzvLcTsCa/SkgZghf9drLocQ/pMvngTx+5gtg
+HCDexfO2F+OwCm5JcToLZLfcNkcUocEU6F9KXHdDVAvlGrQHwGfeFkLrc9f/L4TD
+iIgPLo8e05BCiVWr/0xgegsfNpemddjTCWeUV23RHrUEFW9XhQWXH/ShMyYoSAkl
+Tl6yLnL5YpXWeBdPXd9EgA==
 -----END CERTIFICATE-----
-Certificate:
-    Data:
-        Version: 3 (0x2)
-        Serial Number:
-            d0:94:11:ca:45:ba:b5:f1
-        Signature Algorithm: sha512WithRSAEncryption
-        Issuer: C=DE, ST=Mecklenburg-Vorpommern, O=Opennet Initiative e.V., OU=Opennet CA, CN=opennet-root.ca.on/emailAddress=admin@opennet-initiative.de
-        Validity
-            Not Before: Dec 22 00:00:00 2013 GMT
-            Not After : Dec 21 23:59:59 2033 GMT
-        Subject: C=DE, ST=Mecklenburg-Vorpommern, O=Opennet Initiative e.V., OU=Opennet CA, CN=opennet-root.ca.on/emailAddress=admin@opennet-initiative.de
-        Subject Public Key Info:
-            Public Key Algorithm: rsaEncryption
-            RSA Public Key: (4096 bit)
-                Modulus (4096 bit):
-                    00:d6:b7:ad:01:d9:5e:c6:d3:55:c5:93:1b:c8:62:
-                    82:07:a7:31:12:24:77:e5:5b:73:05:94:96:2b:cc:
-                    41:6b:b9:45:38:89:c5:e7:1c:72:58:1f:39:5f:19:
-                    1e:31:88:c2:8b:9a:71:2e:c8:67:dd:c7:92:bb:ad:
-                    cf:03:4c:83:5b:4a:dd:ec:8d:72:5a:d0:7f:f9:d3:
-                    5e:41:b1:a8:83:3c:5f:27:22:b4:78:2a:77:77:0f:
-                    4e:cb:8b:e6:cd:2c:e7:08:1b:82:3a:52:38:11:62:
-                    9a:96:a6:ae:63:45:be:ab:35:24:86:e5:4d:59:72:
-                    d3:c8:eb:4b:41:f1:43:a4:07:a6:21:0b:1f:44:4e:
-                    34:69:ef:8c:27:9e:60:be:58:53:94:46:2d:9b:bf:
-                    2e:33:8e:50:7a:cd:ee:ab:d2:27:34:df:75:0b:96:
-                    6c:33:30:f0:ec:0d:9a:98:85:35:ad:42:ec:ff:86:
-                    f6:fe:38:a7:8c:30:b9:2a:b2:47:74:3f:cc:7e:e0:
-                    6a:d1:90:93:7c:8d:fb:8a:50:1b:78:08:2a:c1:0d:
-                    ad:04:a9:fd:4f:39:15:0a:ac:61:87:37:de:61:78:
-                    19:80:f8:23:22:be:95:01:0c:ab:50:f6:72:0a:eb:
-                    38:f2:f4:30:e9:8f:7b:c6:02:3d:4d:fe:0a:15:9a:
-                    18:b8:71:e8:d8:be:fc:31:39:aa:f6:76:20:7a:16:
-                    91:8a:55:a3:55:1c:00:4e:fc:8d:ae:1d:6e:39:5c:
-                    58:ae:a2:90:86:74:fd:e3:18:7f:04:ee:9e:23:89:
-                    cc:75:91:42:93:68:15:9b:03:7e:a0:86:9a:54:74:
-                    e6:54:b5:16:b5:ff:b7:e5:c5:f0:0f:a2:74:63:83:
-                    80:ce:91:c0:f2:7f:cf:e5:ca:cf:80:fc:ac:ac:12:
-                    f7:61:87:6a:7b:c5:68:f8:f5:93:50:0e:12:44:b4:
-                    4d:db:d3:e1:0f:b4:65:10:55:6c:98:8d:09:03:5c:
-                    06:1f:08:31:16:c8:ca:b6:51:4f:72:c1:0b:38:45:
-                    fc:d0:81:8f:fc:1e:42:83:d7:41:2a:46:72:09:62:
-                    41:60:ad:b2:de:9e:0c:18:17:bb:b2:ae:e6:ca:74:
-                    10:06:87:c1:f7:e4:b3:9f:d9:a0:32:bb:86:a5:e9:
-                    97:7c:c0:8d:45:e4:57:69:93:a1:15:ed:21:6b:aa:
-                    c3:5e:bc:33:fd:ad:b5:86:ff:da:15:45:5e:ee:85:
-                    28:1e:2f:c1:1b:b8:5d:e0:dd:ed:a2:2d:60:c9:8b:
-                    87:71:b9:87:42:8d:bb:39:a0:5f:f2:42:36:96:7d:
-                    60:80:f6:f8:85:c4:61:ca:e6:67:8a:39:dd:99:74:
-                    58:47:51
-                Exponent: 65537 (0x10001)
-        X509v3 extensions:
-            X509v3 Basic Constraints: critical
-                CA:TRUE
-            X509v3 Subject Key Identifier: 
-                FA:DA:A6:25:24:2C:20:E7:E5:A3:5F:2F:9F:6B:C1:EA:19:1A:F8:C1
-            X509v3 Key Usage: 
-                Certificate Sign, CRL Sign
-            X509v3 CRL Distribution Points: 
-                URI:http://ca.opennet-initiative.de/root.crl
-
-            Netscape Cert Type: 
-                SSL CA, S/MIME CA, Object Signing CA
-            Netscape Base Url: 
-                http://ca.opennet-initiative.de/
-            Netscape Revocation Url: 
-                http://ca.opennet-initiative.de/root.crl
-            Netscape CA Revocation Url: 
-                http://ca.opennet-initiative.de/root.crl
-            Netscape CA Policy Url: 
-                http://ca.opennet-initiative.de/
-            Netscape Comment: 
-                Opennet Root CA
-    Signature Algorithm: sha512WithRSAEncryption
-        05:cf:01:9d:3a:ac:b6:a6:70:8c:72:57:66:da:97:ed:d6:f7:
-        b2:24:9c:ce:75:5a:0d:db:26:86:fb:f5:2f:b3:08:b3:b2:c7:
-        e2:77:5f:9b:61:1b:8c:12:7c:ee:e0:d1:51:f1:59:7f:66:4c:
-        d3:c4:f0:06:d4:45:12:71:78:15:5e:75:d9:61:c5:fc:a7:10:
-        8b:48:44:1a:a7:9e:80:ee:30:d6:3c:a2:1b:68:c7:ac:77:78:
-        c6:d3:70:67:6a:d0:f8:80:0e:7b:8f:d9:a3:3c:75:6a:eb:f3:
-        8e:77:83:d8:d0:a8:c6:49:b4:09:a5:47:14:d2:31:5f:3b:fd:
-        a5:fa:c2:78:80:0c:b4:a0:f6:6e:27:5e:49:f1:43:d8:72:18:
-        af:9d:23:a1:b0:ea:63:06:6e:59:ed:06:4b:93:a4:bb:a3:4a:
-        36:f3:b8:5b:f9:dc:00:ec:49:46:c2:51:5b:da:e0:64:0e:71:
-        22:7b:4b:f5:8b:a0:98:c3:c2:c0:e4:3e:f5:11:99:6c:3f:1f:
-        64:51:7f:c5:2b:e6:8f:8f:84:20:f9:52:bc:b7:74:63:ee:c5:
-        75:cc:7f:5c:91:6a:e6:5f:21:4c:df:3e:cc:75:b0:80:15:84:
-        92:f7:02:52:c6:0f:10:f4:2a:75:64:d2:2b:64:c3:32:42:4b:
-        2b:6d:90:1f:6a:cf:ee:69:20:70:30:27:7b:3b:ac:cf:e5:f3:
-        37:cb:2c:29:d4:9d:3d:49:3f:3f:e2:75:33:f0:d8:41:24:c2:
-        c1:4b:6c:05:92:9c:ad:84:77:04:63:86:5a:05:b6:82:92:45:
-        b6:a6:02:8c:4c:fc:ee:e0:90:d2:a2:b3:e6:74:f5:88:7e:8a:
-        05:35:8b:af:24:39:bd:7e:ef:4a:9d:30:7a:cb:94:dc:c7:42:
-        ef:99:e2:74:03:0c:44:80:97:da:f6:75:68:1e:67:2a:3d:d2:
-        cc:e0:98:2a:cb:fb:15:c6:f6:83:9f:b9:20:74:fc:db:38:8d:
-        c3:94:a4:bb:71:ea:4c:1f:61:d3:4d:d6:a3:35:dd:41:cb:f8:
-        70:97:ee:4c:ac:82:be:10:c1:17:59:1a:44:7d:76:91:aa:91:
-        7e:48:79:3d:0d:d6:98:d9:e4:8f:76:89:fa:61:ec:de:a6:9b:
-        7e:85:d0:88:16:2e:82:fa:1e:4b:82:3c:e3:01:c6:5e:fa:29:
-        b3:1e:e8:a7:14:82:2f:69:93:da:02:93:12:50:44:01:cd:5a:
-        3e:1b:e2:c4:2b:22:51:3b:62:c4:e1:1e:d4:71:8d:c8:63:7f:
-        9f:bd:ce:00:43:76:d3:99:e5:c3:7d:32:03:ae:44:a5:ca:3e:
-        b9:01:c8:4c:02:c8:e4:55
 -----BEGIN CERTIFICATE-----
 MIIHZjCCBU6gAwIBAgIJANCUEcpFurXxMA0GCSqGSIb3DQEBDQUAMIGuMQswCQYD
 VQQGEwJERTEfMB0GA1UECBMWTWVja2xlbmJ1cmctVm9ycG9tbWVybjEgMB4GA1UE
 ChMXT3Blbm5ldCBJbml0aWF0aXZlIGUuVi4xEzARBgNVBAsTCk9wZW5uZXQgQ0Ex
 GzAZBgNVBAMTEm9wZW5uZXQtcm9vdC5jYS5vbjEqMCgGCSqGSIb3DQEJARYbYWRt
-aW5Ab3Blbm5ldC1pbml0aWF0aXZlLmRlMB4XDTEzMTIyMjAwMDAwMFoXDTMzMTIy
-MTIzNTk1OVowga4xCzAJBgNVBAYTAkRFMR8wHQYDVQQIExZNZWNrbGVuYnVyZy1W
+aW5Ab3Blbm5ldC1pbml0aWF0aXZlLmRlMB4XDTIzMDcwOTAwMDAwMFoXDTM4MDcw
+ODIzNTk1OVowga4xCzAJBgNVBAYTAkRFMR8wHQYDVQQIExZNZWNrbGVuYnVyZy1W
 b3Jwb21tZXJuMSAwHgYDVQQKExdPcGVubmV0IEluaXRpYXRpdmUgZS5WLjETMBEG
 A1UECxMKT3Blbm5ldCBDQTEbMBkGA1UEAxMSb3Blbm5ldC1yb290LmNhLm9uMSow
 KAYJKoZIhvcNAQkBFhthZG1pbkBvcGVubmV0LWluaXRpYXRpdmUuZGUwggIiMA0G
@@ -263,16 +69,16 @@ bm5ldC1pbml0aWF0aXZlLmRlLzA3BglghkgBhvhCAQMEKhYoaHR0cDovL2NhLm9w
 ZW5uZXQtaW5pdGlhdGl2ZS5kZS9yb290LmNybDA3BglghkgBhvhCAQQEKhYoaHR0
 cDovL2NhLm9wZW5uZXQtaW5pdGlhdGl2ZS5kZS9yb290LmNybDAvBglghkgBhvhC
 AQgEIhYgaHR0cDovL2NhLm9wZW5uZXQtaW5pdGlhdGl2ZS5kZS8wHgYJYIZIAYb4
-QgENBBEWD09wZW5uZXQgUm9vdCBDQTANBgkqhkiG9w0BAQ0FAAOCAgEABc8BnTqs
-tqZwjHJXZtqX7db3siScznVaDdsmhvv1L7MIs7LH4ndfm2EbjBJ87uDRUfFZf2ZM
-08TwBtRFEnF4FV512WHF/KcQi0hEGqeegO4w1jyiG2jHrHd4xtNwZ2rQ+IAOe4/Z
-ozx1auvzjneD2NCoxkm0CaVHFNIxXzv9pfrCeIAMtKD2bideSfFD2HIYr50jobDq
-YwZuWe0GS5Oku6NKNvO4W/ncAOxJRsJRW9rgZA5xIntL9YugmMPCwOQ+9RGZbD8f
-ZFF/xSvmj4+EIPlSvLd0Y+7Fdcx/XJFq5l8hTN8+zHWwgBWEkvcCUsYPEPQqdWTS
-K2TDMkJLK22QH2rP7mkgcDAnezusz+XzN8ssKdSdPUk/P+J1M/DYQSTCwUtsBZKc
-rYR3BGOGWgW2gpJFtqYCjEz87uCQ0qKz5nT1iH6KBTWLryQ5vX7vSp0wesuU3MdC
-75nidAMMRICX2vZ1aB5nKj3SzOCYKsv7Fcb2g5+5IHT82ziNw5Sku3HqTB9h003W
-ozXdQcv4cJfuTKyCvhDBF1kaRH12kaqRfkh5PQ3WmNnkj3aJ+mHs3qabfoXQiBYu
-gvoeS4I84wHGXvopsx7opxSCL2mT2gKTElBEAc1aPhvixCsiUTtixOEe1HGNyGN/
-n73OAEN205nlw30yA65Epco+uQHITALI5FU=
+QgENBBEWD09wZW5uZXQgUm9vdCBDQTANBgkqhkiG9w0BAQ0FAAOCAgEAVslwTTfv
+v0d5SMuNwQzFZaAtu57hHuOo6nYVGX4SrWpJFOUX1lq9qgc9DOgfydX4zPm367uV
+FfZBNzY/EuM3zsJ6I9GhNcJTx3Lxao9t8dRDIe2JEcwwX2uo47q88AN1+lqTc3G1
+42rvrdZFULx77xfXMhgXGTm/wAwbc2oRH5JlDNOGN4fzeShDDOrTAZLRfFMW3uMa
+qQpFiHZpQYoZp45BAQmoLKhKjMdrLyswc58NL1WT4VVlusGDTlaLADF1Vuw2oW7D
+I9GckmP38v0XCQryMSNwPvKWxsiEtFIT+iUimf7DzNAnk+BZwEwIs9/9EnNLgtaJ
+XsNdmmM6MmVz5ymUEzbo6jPxi8LNl94nEO50LLtyH0dup8TbPlho4hR2lX2jJErs
+nxKh+bXpmwrVpcvNYAMgBtWPaXykbrEgFeUg96YT5/G2FuXSlVZRwYqxQ5oKKCpZ
+0YNhHYpSV0KBHdzJrzJVWed6/dsWvC7HLb8FShaAv+PRBC1pzsax2TZ2WZv5yeX1
+C6c1VGJd4H97/iTQgQxANSEU1qezA8C0s/vWlfyYrpeIyIlIJwT9MlMBvwnAKFtj
+1WdJqp8IQH2ntvDPrUAGIeNbx6BAt0O4xa/6yls92rN1tM/dyBBZ9MpQEeJG+nWJ
+X4D+WJ879onydKgJEIBQHpdn2ERLDCkOeU0=
 -----END CERTIFICATE-----

--- a/roles/gateway-server/templates/openvpn/opennet_ugw.conf
+++ b/roles/gateway-server/templates/openvpn/opennet_ugw.conf
@@ -10,6 +10,7 @@ port 1602
 proto udp6
 max-clients 100
 
+{% if debian_release != "buster" %}
 # Ältere Clients (u.a. v.0.5.3) können sich Clients seit Debian Bullseye
 # (OpenVPN 2.5) nicht mehr verbinden. Laut der OpenVPN-Doku ist dieses Problem
 # gegenüber Clients der Version 2.3 (Opennet Firmware 0.5.3) oder älter erwartbar.
@@ -21,6 +22,7 @@ max-clients 100
 # verwendbar ist.
 # Quelle: https://community.openvpn.net/openvpn/wiki/CipherNegotiation#Serverversion2.5Configuring:--data-ciphers
 data-ciphers AES-256-GCM:AES-128-GCM:AES-256-CBC:BF-CBC
+{% endif %}
 
 # Ohne die multihome-Option ermittelt openvpn selbst seine Quell-Adresse beim
 # Beantworten von Anfragen. Dies ist fuer uns unerwuenscht, wenn es mehrere

--- a/roles/gateway-server/templates/openvpn/opennet_user6.conf
+++ b/roles/gateway-server/templates/openvpn/opennet_user6.conf
@@ -9,6 +9,20 @@ port 1700
 proto udp6
 max-clients 100
 
+{% if debian_release != "buster" %}
+# Ältere Clients (u.a. v.0.5.3) können sich Clients seit Debian Bullseye
+# (OpenVPN 2.5) nicht mehr verbinden. Laut der OpenVPN-Doku ist dieses Problem
+# gegenüber Clients der Version 2.3 (Opennet Firmware 0.5.3) oder älter erwartbar.
+# Laut OpenVPN-Doku hätte eigentlich die Verwendung von
+# "--data-ciphers-fallback BF-CBC" für unsere Konstellation passend sein sollen
+# (da wir die Build-Option "--enable-small" auf den Routern einsetzen), allerdings
+# funktioniert dann aus unklaren Gründen der Verbindungsaufbau nicht.
+# Daher verwenden wir eine explizite Ciphers-Liste, die auch für v2.3-Clients
+# verwendbar ist.
+# Quelle: https://community.openvpn.net/openvpn/wiki/CipherNegotiation#Serverversion2.5Configuring:--data-ciphers
+data-ciphers AES-256-GCM:AES-128-GCM:AES-256-CBC:BF-CBC
+{% endif %}
+
 # Zertifikate
 ca /etc/openvpn/opennet_users/ca.crt
 cert {{ openvpn_ugw_cert_file }}

--- a/roles/gateway-server/templates/openvpn/opennet_users.conf
+++ b/roles/gateway-server/templates/openvpn/opennet_users.conf
@@ -23,6 +23,7 @@ crl-verify /etc/ssl/crl/opennet-vpn-user.crl
 # Siehe https://community.openvpn.net/openvpn/ticket/1211
 tls-version-min 1.0
 
+{% if debian_release != "buster" %}
 # Ältere Clients (u.a. v.0.5.3) können sich Clients seit Debian Bullseye
 # (OpenVPN 2.5) nicht mehr verbinden. Laut der OpenVPN-Doku ist dieses Problem
 # gegenüber Clients der Version 2.3 (Opennet Firmware 0.5.3) oder älter erwartbar.
@@ -34,6 +35,7 @@ tls-version-min 1.0
 # verwendbar ist.
 # Quelle: https://community.openvpn.net/openvpn/wiki/CipherNegotiation#Serverversion2.5Configuring:--data-ciphers
 data-ciphers AES-256-GCM:AES-128-GCM:AES-256-CBC:BF-CBC
+{% endif %}
 
 # Ohne die multihome-Option ermittelt openvpn selbst seine Quell-Adresse beim
 # Beantworten von Anfragen. Dies ist fuer uns unerwuenscht, wenn es mehrere


### PR DESCRIPTION
When we merge this PR and run ansible afterwards against other gateway servers then they also get the new CA.
I am not sure whether the gateway servers need a new certificate before (from new CA) or not.