### PR TITLE
Add role to build ipq40xx_mikrotik

### DIFF
--- a/roles/buildbot-controller/templates/master.cfg.j2
+++ b/roles/buildbot-controller/templates/master.cfg.j2
@@ -118,6 +118,7 @@ factory.addStep(steps.ShellCommand(name="bcm2708", command=["make", "-j2", "bcm2
 factory.addStep(steps.ShellCommand(name="bcm2709", command=["make", "-j2", "bcm2709"], description="make bcm2709", timeout=3600, doStepIf=enforcedMakeArchAll))
 factory.addStep(steps.ShellCommand(name="bcm2710", command=["make", "-j2", "bcm2710"], description="make bcm2710", timeout=3600, doStepIf=enforcedMakeArchAll))
 factory.addStep(steps.ShellCommand(name="ipq40xx", command=["make", "-j2", "ipq40xx"], description="make ipq40xx", timeout=3600, doStepIf=enforcedMakeArchAll))
+factory.addStep(steps.ShellCommand(name="ipq40xx_mikrotik", command=["make", "-j2", "ipq40xx_mikrotik"], description="make ipq40xx_mikrotik", timeout=3600, doStepIf=enforcedMakeArchAll))
 factory.addStep(steps.ShellCommand(name="mediatek", command=["make", "-j2", "mediatek"], description="make mediatek", timeout=3600))
 factory.addStep(steps.ShellCommand(name="mikrotik", command=["make", "-j2", "mikrotik"], description="make mikrotik", timeout=3600))
 factory.addStep(steps.ShellCommand(name="mikrotik24", command=["make", "-j2", "mikrotik24"], description="make mikrotik24", timeout=3600, doStepIf=enforcedMakeArchAll))


### PR DESCRIPTION
Ich würde gerne unsere Firmware für ein neues Gerät bauen lassen.
Hier ist die Regel für den buildbot-controller damit der build für ipq40xx_mikrotik in die Routine aufgenommen wird. 