### PR TITLE
Add folder description to on-workarounds

### DIFF
--- a/roles/apache2-server/templates/apache2-sites.d/downloads.inc
+++ b/roles/apache2-server/templates/apache2-sites.d/downloads.inc
@@ -24,6 +24,7 @@ Alias /openwrt/testing /var/www/downloads-buildbot/export
   AddDescription "Opennet Firmware (Current Releases)" stable
   AddDescription "Opennet Firmware (Development Builds)" testing
   AddDescription "Opennet Firmware (Other Builds)" misc
+  AddDescription "Opennet Firmware (on-workarounds)" workarounds
 </Directory>
 <Directory /var/www/downloads/openwrt/stable>
   IndexOrderDefault Descending Name


### PR DESCRIPTION
Ich würde für das nachladen von Code für on-workarounds die Adresse downloads.opennet-initiative.de verwenden.

Hier soll ein Ordner mit dem Namen workarounds angelegt werden, von wo aus das Skript on-workarounds zugreift.
Damit soll https://github.com/opennet-initiative/firmware/issues/2#issue-1225686023 gelöst werden.